### PR TITLE
`output_dir` as Pathlib object instead of posix string

### DIFF
--- a/element_deeplabcut/model.py
+++ b/element_deeplabcut/model.py
@@ -753,7 +753,7 @@ class PoseEstimation(dj.Computed):
             )
 
         try:
-            output_dir = find_full_path(get_dlc_root_data_dir(), output_dir).as_posix()
+            output_dir = find_full_path(get_dlc_root_data_dir(), output_dir)
         except FileNotFoundError as e:
             if task_mode == "trigger":
                 processed_dir = Path(get_dlc_processed_data_dir())


### PR DESCRIPTION
To resolve the following: 
```
Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/site-packages/datajoint/autopopulate.py", line 315, in _populate1
    make(dict(key), **(make_kwargs or {}))
  File "/opt/conda/lib/python3.10/site-packages/element_deeplabcut/model.py", line 898, in make
    for f in output_dir.rglob("*")
AttributeError: 'str' object has no attribute 'rglob'
```